### PR TITLE
Added save/load function to core

### DIFF
--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import six
 import warnings
+import pickle
 
 from .mappers import ContinuousMapper, ObjectMapper
 from .utils import check_random_state
@@ -154,7 +155,7 @@ def entrofy(dataframe, n,
             max_score = score
             best = solution
 
-    return dataframe.index[best], max_score
+    return dataframe.index[best], max_score, mappers
 
 
 def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=0.5):
@@ -230,3 +231,109 @@ def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=
 
 def __objective(p, w, q, alpha=0.5):
     return ((np.minimum(q, p))**(alpha)).dot(w)
+
+
+def save(idx, filename,
+         dataframe=None,
+         mappers=None,
+         weights=None,
+         pre_selects=None,
+         opt_outs=None,
+         quantile=0.1,
+         n_trials=15,
+         seed=None,
+         alpha=0.5):
+
+    """
+    Save an Entrofy run to disk.
+    The data will be saved in a pickle file containing a dictionary with
+    "par":object pairs, where "par" refers to the parameters defined below.
+
+    If the default values had been used for the entrofy run, most of these
+    can be left at their defaults here, too.
+
+    Parameters
+    ----------
+    idx : iterable
+        The indices of selected participants returned by `entrofy`.
+
+    filename : str
+        The file name to save the run to.
+
+    dataframe : pd.DataFrame
+        Rows are participants, and columns are attributes.
+
+    mappers : optional, dict {column: entrofy.BaseMapper}
+        Dictionary mapping dataframe columns to BaseMapper objects
+
+    weights : optional, dict {column: float}
+        Weighting over dataframe columns
+
+    pre_selects : None or iterable
+        Optionally, you may pre-specify a set of rows to be forced into the
+        solution.
+        Values must be valid indices for dataframe.
+
+    opt-out : None or iterable
+        Optionally, you may pre-specify a set of rows to be ignored when
+        searching for a solution.
+        Values must be valid indices for dataframe.
+
+    quantile : float, values in [0,1]
+        Define the quantile to be used in tie-breaking between top choices at
+        every step; choose e.g. 0.01 for the top 1% quantile
+        By default, 0.01
+
+    n_trials : int > 0
+        If pre_selects is None, run `n_trials` random initializations and return
+        the solution with the best objective value.
+
+    seed : [optional] int or numpy.random.RandomState
+        An optional seed or random number state.
+
+    alpha : float in (0, 1]
+        Scaling exponent for the objective function.
+
+    """
+    state = {"index": idx, "mappers": mappers,
+             "weights": weights, "pre_selects": pre_selects,
+             "opt_outs": opt_outs, "quantile":quantile,
+             "n_trials":n_trials, "seed": seed, "alpha": alpha}
+
+    if dataframe is not None:
+        state["dataframe"] = dataframe
+
+    f = open(filename, "w")
+    pickle.dump(state, f)
+    f.close()
+
+    return
+
+
+def load(filename):
+    """
+    Load a previous run from disk.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to which the entrofy run has been previously saved.
+
+    Returns
+    -------
+    state : dict, "par": obj
+        A dictionary with the state of an entrofy run. Dictionary keywords
+        correspond to the input parameters to `entrofy`, with two exceptions:
+        (1) saving the input DataFrame is optional, hence if it has not been
+        saved, it will not be present in the dictionary. (2) The dictionary also
+        contains an iterable `idx` with the indices of the selected participants
+        from the previous entrofy run.
+    """
+
+    f = open(filename, 'r')
+    state = pickle.load(f)
+    f.close()
+
+    return state
+
+

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -155,7 +155,7 @@ def entrofy(dataframe, n,
             max_score = score
             best = solution
 
-    return dataframe.index[best], max_score, mappers
+    return dataframe.index[best], max_score
 
 
 def __entrofy(X, k, rng, w=None, q=None, pre_selects=None, quantile=0.01, alpha=0.5):

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -378,10 +378,9 @@ def load(filename, dataframe=None):
         from the previous entrofy run.
     """
 
-    f = open(filename, 'r')
-    state = pickle.load(f)
-    f.close()
-
+    with open(filename, 'r') as f:
+        state = pickle.load(f)
+    
     data_types = state["data_types"]
     boundaries = state["boundaries"]
     targets = state["targets"]

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -119,6 +119,8 @@ class ObjectMapper(BaseMapper):
             An optional pre-computed target dictionary.
             If provided, then `n_out` and `prefix` are ignored.
         '''
+        self.prefix = prefix
+
         if targets is not None:
             self.targets = targets
             self._map = {v: equal_maker(v) for v in targets}


### PR DESCRIPTION
I've been thinking about the general workflow more. I really think thought it would be useful to have a load/save function. In practice, users will probably run entrofy, send out invitations, and weeks later come back and try to do a second run. They'll probably have forgotten what they did previously, which settings they used, which seed, etc. Having the ability to store and restore a full previous run with all relevant parameters would help them by not having to start from scratch. 