### PR TITLE
fixed bug in prefix naming of mappers

### DIFF
--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -125,7 +125,6 @@ def entrofy(dataframe, n,
     '''
 
     rng = check_random_state(seed)
-    print(rng)
 
     # Drop the opt-outs
     if opt_outs is not None:

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pandas as pd
+import six 
 
 __all__ = ['ObjectMapper', 'BaseMapper', 'ContinuousMapper']
 
@@ -83,11 +84,18 @@ class BaseMapper(object):
         nonnulls = ~column.isnull()
 
         for key in self._map:
-            df[key][nonnulls] = column[nonnulls].apply(self._map[key])
-            df[key][~nonnulls] = None
+            df['{}{}'.format(self.prefix, key)][nonnulls] = column[nonnulls].apply(self._map[key])
+            df['{}{}'.format(self.prefix, key)][~nonnulls] = None
 
         return df
 
+    def _prepend_prefix(self, targets, prefix):
+        new_targets = {}
+        for key, t in six.iteritems(targets):
+            new_key = '{}{}'.format(prefix, key)
+            new_targets[new_key] = t
+
+        return new_targets
 
 class ObjectMapper(BaseMapper):
     '''A generic object-mapper.
@@ -122,7 +130,7 @@ class ObjectMapper(BaseMapper):
         self.prefix = prefix
 
         if targets is not None:
-            self.targets = targets
+            self.targets = self._prepend_prefix(targets, prefix)
             self._map = {v: equal_maker(v) for v in targets}
         else:
             # 1. determine unique values

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -89,10 +89,10 @@ class BaseMapper(object):
 
         return df
 
-    def _prepend_prefix(self, targets, prefix):
+    def _prepend_prefix(self, targets):
         new_targets = {}
         for key, t in six.iteritems(targets):
-            new_key = '{}{}'.format(prefix, key)
+            new_key = '{}{}'.format(self.prefix, key)
             new_targets[new_key] = t
 
         return new_targets
@@ -130,7 +130,7 @@ class ObjectMapper(BaseMapper):
         self.prefix = prefix
 
         if targets is not None:
-            self.targets = self._prepend_prefix(targets, prefix)
+            self.targets = self._prepend_prefix(targets)
             self._map = {v: equal_maker(v) for v in targets}
         else:
             # 1. determine unique values

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -112,7 +112,7 @@ def plot_fractions(column, idx, key, mapper, ax = None):
     return ax, summary
 
 
-def plot(df, idx, weights, mappers=None, cols=4):
+def plot(df, idx, weights=None, mappers=None, cols=4):
     """
     Plot bar plots for all columns in the DataFrame.
 

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -112,7 +112,7 @@ def plot_fractions(column, idx, key, mapper, ax = None):
     return ax, summary
 
 
-def plot(df, idx, weights=None, mappers=None, cols=4):
+def plot(df, idx, weights, mappers=None, cols=4):
     """
     Plot bar plots for all columns in the DataFrame.
 
@@ -146,7 +146,6 @@ def plot(df, idx, weights=None, mappers=None, cols=4):
     rows = np.floor(ncolumns/cols)
     if (ncolumns % cols) > 0:
         rows += 1
-
 
     fig = plt.figure(figsize=(4*cols, 3*rows))
 


### PR DESCRIPTION
When running Entrofy for Astro Hack Week today, I noticed that attributes that have the same name across categories cause an error when binarizing the table: it seems that the prefix isn't applied to the column name, especially when targets are passed into a `BaseMapper` subclass. So I fixed that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dhuppenkothen/entrofy/31)
<!-- Reviewable:end -->
