### PR TITLE
Correct string formatting for mappers and probabilities.

### DIFF
--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -179,7 +179,7 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
         new_df = mapper.transform(dataframe[key])
         df_binary = df_binary.join(new_df)
         all_weights.update({k: weights[key] for k in new_df.columns})
-        all_probabilities.update({'{}{}'.format(mapper.prefix, k):mapper.targets[k] for k in mapper.targets.keys()})
+        all_probabilities.update({'{}{}'.format(mapper.prefix, k):mapper.targets[k] for k in mapper.targets})
 
     # Construct the target probability vector and weight vector
     target_prob = np.empty(len(df_binary.columns))

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -179,7 +179,7 @@ def entrofy(dataframe, n, mappers=None, weights=None, pre_selects=None,
         new_df = mapper.transform(dataframe[key])
         df_binary = df_binary.join(new_df)
         all_weights.update({k: weights[key] for k in new_df.columns})
-        all_probabilities.update(mapper.targets)
+        all_probabilities.update({'{}{}'.format(mapper.prefix, k):mapper.targets[k] for k in mapper.targets.keys()})
 
     # Construct the target probability vector and weight vector
     target_prob = np.empty(len(df_binary.columns))

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -77,8 +77,10 @@ class BaseMapper(object):
             A DataFrame with the same index as `column`, and one binary-valued
             column for each potential output.
         '''
+        new_columns =  sorted(['{}{}'.format(self.prefix, key) for key in self.targets.keys()])
         df = pd.DataFrame(index=column.index,
-                          columns=sorted(list(self.targets.keys())),
+                          #columns=sorted(list(self.targets.keys())),
+                          columns = new_columns,
                           dtype=float)
 
         nonnulls = ~column.isnull()

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -77,7 +77,7 @@ class BaseMapper(object):
             A DataFrame with the same index as `column`, and one binary-valued
             column for each potential output.
         '''
-        new_columns =  sorted(['{}{}'.format(self.prefix, key) for key in self.targets.keys()])
+        new_columns =  sorted(['{}{}'.format(self.prefix, key) for key in self.targets])
         df = pd.DataFrame(index=column.index,
                           #columns=sorted(list(self.targets.keys())),
                           columns = new_columns,


### PR DESCRIPTION
I just ran entrofy on a bunch of categories that all had "yes"/"no" answers, and ran into problems when defining the prefixes. This PR should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dhuppenkothen/entrofy/33)
<!-- Reviewable:end -->
