### PR TITLE
Fixed small bug in mappers

### DIFF
--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -132,7 +132,7 @@ class ObjectMapper(BaseMapper):
         self.prefix = prefix
 
         if targets is not None:
-            self.targets = self._prepend_prefix(targets)
+            self.targets = targets
             self._map = {v: equal_maker(v) for v in targets}
         else:
             # 1. determine unique values

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -105,7 +105,7 @@ def plot_fractions(column, idx, key, mapper, ax = None):
     ax.set_ylabel("Fraction of sample")
 
     xticklabels = [x.get_text() for x in ax.get_xticklabels()]
-    xtick_new = xtick_new = [x.split("_")[1] if len(x.split("_"))>1 else x for x in xticklabels]
+    xtick_new = [x.split("_")[1] if len(x.split("_"))>1 else x for x in xticklabels]
     ax.set_xticklabels(xtick_new)
 
     # add targets

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -104,6 +104,10 @@ def plot_fractions(column, idx, key, mapper, ax = None):
     sns.barplot(x=key, y="counts", hue="type", data=summary, ax=ax)
     ax.set_ylabel("Fraction of sample")
 
+    xticklabels = [x.get_text() for x in ax.get_xticklabels()]
+    xtick_new = xtick_new = [x.split("_")[1] if len(x.split("_"))>1 else x for x in xticklabels]
+    ax.set_xticklabels(xtick_new)
+
     # add targets
     for i,l in enumerate(np.sort(list(mapper.targets.keys()))):
         ax.hlines(mapper.targets[l], -0.5+i*1.0, 0.5+i*1.0, lw=2,


### PR DESCRIPTION
 where _prepend_prefix got called twice in some instances (once when creating mappers, and again in the `transform` method, which causes problems when actually running Entrofy).

Also made xticklabels a little nicer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dhuppenkothen/entrofy/39)
<!-- Reviewable:end -->
