### PR TITLE
Py3 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8
 
 before_install:
     - bash .travis_dependencies.sh
@@ -29,4 +31,3 @@ script:
 
 after_success:
     - coveralls
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ notifications:
 
 python:
     - 2.7
-    - 3.4
-    - 3.5
     - 3.6
     - 3.7
     - 3.8

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -11,7 +11,7 @@ conda_create ()
     conda update -q conda
     conda config --add channels pypi
     conda info -a
-    deps='six nose coverage pip numpy scipy pandas matplotlib'
+    deps='six nose coverage pip numpy scipy pandas matplotlib future'
 
     conda create -q -n $ENV_NAME "python=$TRAVIS_PYTHON_VERSION" $deps
 }
@@ -20,7 +20,7 @@ src="$HOME/env/miniconda$TRAVIS_PYTHON_VERSION"
 if [ ! -d "$src" ]; then
     mkdir -p $HOME/env
     pushd $HOME/env
-    
+
         # Download miniconda packages
         wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
 
@@ -28,12 +28,12 @@ if [ ! -d "$src" ]; then
         bash miniconda.sh -b -p $src
 
         export PATH="$src/bin:$PATH"
-        conda_create 
+        conda_create
 
         source activate $ENV_NAME
 
         pip install python-coveralls
-            
+
         source deactivate
     popd
 else

--- a/entrofy/core.py
+++ b/entrofy/core.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 '''Entrofy core optimization routines'''
 
+from builtins import range
 import warnings
 from six.moves import cPickle as pickle
 

--- a/entrofy/mappers.py
+++ b/entrofy/mappers.py
@@ -2,6 +2,9 @@
 # -*- encoding: utf-8 -*-
 '''Column mapper object definitions'''
 
+from builtins import zip
+from builtins import range
+from builtins import object
 import numpy as np
 import pandas as pd
 import six 

--- a/entrofy/plotting.py
+++ b/entrofy/plotting.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import zip
+from builtins import range
 import matplotlib.pyplot as plt
 import matplotlib
 
@@ -230,7 +232,7 @@ def _plot_categorical(df, xlabel, ylabel, x_keys, y_keys, prefac, ax, cmap, s):
             counts.append(len(df[(df[xlabel] == x_keys[i]) &
                                  (df[ylabel] == y_keys[j])]))
 
-    x, y = zip(*tuples)
+    x, y = list(zip(*tuples))
 
     cmap = plt.cm.get_cmap(cmap)
     sizes = (np.array(counts)/np.sum(counts))

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     license='ISC',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup, find_packages
-
 import imp
+
+from setuptools import find_packages, setup
 
 version = imp.load_source('entrofy.version', 'entrofy/version.py')
 
@@ -33,7 +33,8 @@ setup(
         'pandas>=0.18',
         'numpy>=1.10',
         'seaborn>=0.6.0',
-        'matplotlib>=1.4.3'
+        'matplotlib>=1.4.3',
+        'future',
     ],
     extras_require={
         'docs': ['numpydoc']


### PR DESCRIPTION
I used the python-future package to inspect all of the `.py` files in the project and apply auto-fixes that make the code more compatible with Python 3. python-future also automatically makes the changes needed to keep Python 2.x compatibility.

Keeping Python 2 support also necessitates adding the `future` package as a dependency for `entrofy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dhuppenkothen/entrofy/63)
<!-- Reviewable:end -->
